### PR TITLE
make SevenZip.getSevenZipJBindingVersion() reflect current version...

### DIFF
--- a/sevenzipjbinding/build.gradle
+++ b/sevenzipjbinding/build.gradle
@@ -29,8 +29,12 @@ android {
     compileSdk 35
     ndkVersion '27.2.12479018'
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_21
-        targetCompatibility JavaVersion.VERSION_21
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
+    }
+
+    buildFeatures {
+        buildConfig = true
     }
 
     publishing {
@@ -46,7 +50,12 @@ android {
         namespace 'net.sf.sevenzipjbinding'
 
         versionCode 1
-        versionName "2024.12"
+        versionName "2025.01.26"
+
+        // these values are not written by com.android.library by default
+        // see https://stackoverflow.com/questions/64333763
+        buildConfigField 'int', 'VERSION_CODE', "${versionCode}"
+        buildConfigField 'String', 'VERSION_NAME', "\"${versionName}\""
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
@@ -73,9 +82,9 @@ android {
 publishing {
     publications {
         release(MavenPublication) {
-            groupId = 'com.github.lings03'
+            groupId = 'com.github.edeso'
             artifactId = '7-Zip-JBinding-4Android'
-            version = '2024.12'
+            version = android.defaultConfig.versionName
 
             afterEvaluate {
                 from components.release

--- a/sevenzipjbinding/src/main/java/net/sf/sevenzipjbinding/SevenZip.java
+++ b/sevenzipjbinding/src/main/java/net/sf/sevenzipjbinding/SevenZip.java
@@ -193,7 +193,7 @@ public class SevenZip {
     }
 
     // Also change in /CMakeLists.txt
-    private static final String SEVENZIPJBINDING_VERSION = "16.02-2.02";
+    private static final String SEVENZIPJBINDING_VERSION = BuildConfig.VERSION_NAME;
 
     private static final String SYSTEM_PROPERTY_TMP = "java.io.tmpdir";
     private static final String SYSTEM_PROPERTY_SEVEN_ZIP_NO_DO_PRIVILEGED_INITIALIZATION = "sevenzip.no_doprivileged_initialization";


### PR DESCRIPTION
- lower class sourceCompatibility/targetCompatibility to a more compatible java 11
- use BuildConfig to distribute versionName to SevenZip class

**NOTE:** you may want to revert the group id for the maven publication 