### PR TITLE
lower class versions

### DIFF
--- a/sevenzipjbinding/build.gradle
+++ b/sevenzipjbinding/build.gradle
@@ -29,8 +29,8 @@ android {
     compileSdk 36
     ndkVersion "28.0.13004108"
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_21
-        targetCompatibility JavaVersion.VERSION_21
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     buildFeatures {

--- a/sevenzipjbinding/build.gradle
+++ b/sevenzipjbinding/build.gradle
@@ -27,7 +27,7 @@ ext {
 
 android {
     compileSdk 36
-    ndkVersion "28.0.13004108"
+    ndkVersion "28.1.13356709"
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11

--- a/sevenzipjbinding/build.gradle
+++ b/sevenzipjbinding/build.gradle
@@ -50,7 +50,7 @@ android {
         namespace 'net.sf.sevenzipjbinding'
 
         versionCode 1
-        versionName "2025.03.21"
+        versionName "2025.04.30-ede"
 
         // these values are not written by com.android.library by default
         // see https://stackoverflow.com/questions/64333763


### PR DESCRIPTION
enforcing is simply unneeded and make it impossible to use the library in projects build with older jdks

jdk11 is a reasonable low default, actually it could still be `JavaVersion.VERSION_1_8` without any negative effect.